### PR TITLE
style: align rustfmt with cargo fmt edition

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,5 @@
-edition = "2024"
+edition = "2021"
+style_edition = "2021"
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
 max_width = 80


### PR DESCRIPTION
Without this change `rustfmt` (used in editors) and `cargo fmt` (used in CI) format differently
