### PR TITLE
feat: derive `InnerIntoHtml` for newtypes, closes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,25 @@ The macro design balances several constraints:
 
 Escaping is done automatically, but can be opted out by wrapping a type with `PreEscaped(..)`.
 
+## Deriving for newtypes
+
+For newtype wrappers (structs with a single unnamed field), you can use the
+`InnerIntoHtml` derive macro to automatically implement `IntoHtml`:
+
+```rust
+use vy::prelude::*;
+
+#[derive(InnerIntoHtml)]
+struct Length((usize, String));
+
+let length = Length((1, "cm".into()));
+assert_eq!(length.into_string(), "1cm");
+```
+
+This delegates the `IntoHtml` implementation to the inner type, reducing
+boilerplate.
+
+
 ## Performance
 
 `vy` utilizes a few practices for fast rendering times:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,4 +104,19 @@ mod tests {
             r#"<button disabled></button>"#
         );
     }
+
+    #[test]
+    fn derive_inner_into_html() {
+        #[derive(InnerIntoHtml)]
+        struct Switch(bool);
+
+        let enabled = Switch(true);
+        assert_eq!(enabled.into_string(), "true");
+
+        #[derive(InnerIntoHtml)]
+        struct Length((usize, String));
+
+        let length = Length((1, "cm".into()));
+        assert_eq!(length.into_string(), "1cm");
+    }
 }


### PR DESCRIPTION
No need to rely on Display actually, just unwrapping a newtype is enough :)