### PR TITLE
chore: pre-commit script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Execute tests
         run: cargo test --workspace --all-features --all-targets
 
+      - name: Test docs
+        run: cargo test --doc
+
   check:
     name: Check
 
@@ -65,3 +68,56 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+  rustdoc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rustdoc
+        run: cargo rustdoc --all-features -- -D warnings
+
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check typos
+        uses: crate-ci/typos@master
+        with:
+          files: .
+
+  cargo_sort:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-sort
+        run: cargo install --locked cargo-sort
+
+      - name: Check sorting
+        run: cargo sort -c
+
+  machete:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install `cargo-machete`
+        run: cargo install --locked cargo-machete
+
+      - name: Check unused dependencies
+        run: cargo machete

--- a/.pre-commit.sh
+++ b/.pre-commit.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+
+set -eu
+
+# Linking the script as the pre-commit hook
+SCRIPT_PATH=$(realpath "$0")
+HOOK_PATH=$(git rev-parse --git-dir)/hooks/pre-commit
+
+if [ "$(realpath "$HOOK_PATH")" != "$SCRIPT_PATH" ]; then
+    printf "Link this script as the git pre-commit hook to avoid further manual running? (y/N): "
+    read -r link_hook
+    case "$link_hook" in
+    [Yy])
+        ln -sf "$SCRIPT_PATH" "$HOOK_PATH"
+        ;;
+    esac
+fi
+
+set -x
+
+# Install tools
+cargo clippy --version >/dev/null 2>&1 || rustup component add clippy
+cargo machete --version >/dev/null 2>&1 || cargo install --locked cargo-machete
+cargo sort --version >/dev/null 2>&1 || cargo install --locked cargo-sort
+typos --version >/dev/null 2>&1 || cargo install --locked typos-cli
+
+rustup toolchain list | grep -q 'nightly' || rustup toolchain install nightly
+cargo +nightly fmt --version >/dev/null 2>&1 || rustup component add rustfmt --toolchain nightly
+
+# Checks
+typos .
+cargo machete
+cargo +nightly fmt -- --check
+cargo sort -c
+cargo rustdoc --all-features -- -D warnings
+cargo test --workspace --all-features --all-targets
+cargo test --workspace --doc
+cargo clippy --all-features --all-targets -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
-[workspace]
-resolver = "2"
-members = ["core", "macros"]
 
 [package]
 name = "vy"
@@ -14,6 +11,9 @@ repository = "https://github.com/JonahLund/vy"
 keywords = ["html", "macros", "template"]
 categories = ["template-engine", "web-programming"]
 license = "MIT"
+[workspace]
+resolver = "2"
+members = ["core", "macros"]
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -82,3 +82,8 @@ Escaping is done automatically, but can be opted out by wrapping a type with `Pr
 - **Pre-calculated sizing**: HTML output size is estimated before allocation.
 - **Single-allocation rendering**: Most templates render in one memory allocation.
 - **Zero-cost composition**: Macros expand to tuple-based [`IntoHtml`] types without closures.
+
+
+## Contributing
+
+You can run `./.pre-commit.sh` before sending a PR, it will check everything the CI does.

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -38,7 +38,7 @@ use core::{
 
 /// Buffer for rendered contents
 ///
-/// This struct is quite simular to `String`, but some methods are
+/// This struct is quite similar to `String`, but some methods are
 /// re-implemented for faster buffering.
 pub struct Buffer {
     data: *mut u8,
@@ -419,7 +419,7 @@ mod tests {
         let mut buf = Buffer::from(s);
         assert_eq!(buf.as_str(), "");
 
-        // capacity should be shrinked for safety
+        // capacity should be shrunk for safety
         assert_eq!(buf.capacity(), 0);
 
         buf.push_str("abc");


### PR DESCRIPTION
Would you be willing to add the script, so contributors won't forget to e.g. add the `--worspace` flag to `cargo test`?

Other changes are related to new checks. I guess they better to match the CI's once. Should I remove them from pre-commit or add to CI?