### PR TITLE
Fix conditional bool attrs

### DIFF
--- a/macros/src/fmt.rs
+++ b/macros/src/fmt.rs
@@ -86,18 +86,12 @@ impl<'s> Serializer<'s> {
     pub fn write_attr(&mut self, attr: Attr) {
         let name = attr.name.to_string();
         if attr.is_optional() {
-            let sep_name = String::from(' ') + &name;
-            let sep_name_eq = sep_name.clone() + "=\"";
-
             match attr.value {
                 AttrValue::Expr(value) => self.write_expr(parse_quote! {
-                    ::core::option::Option::map(
-                        #value,
-                        |val| (::vy::PreEscaped(#sep_name_eq), val, vy::PreEscaped('"'))
-                    )
+                    ::vy::__macro_support::OptionalAttr(#value).render(#name)
                 }),
-                AttrValue::Bool(value) => self.write_expr(parse_quote!{
-                    <bool>::then_some(#value, ::vy::PreEscaped(#sep_name))
+                AttrValue::Bool(value) => self.write_expr(parse_quote! {
+                    ::vy::__macro_support::OptionalAttr(#value).render(#name)
                 }),
             }
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,5 +103,12 @@ mod tests {
             button!(disabled? = true, hidden? = false).into_string(),
             r#"<button disabled></button>"#
         );
+
+        let yes = true;
+        let no = false;
+        assert_eq!(
+            button!(disabled? = yes, hidden? = no).into_string(),
+            r#"<button disabled></button>"#
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod __macro_support {
         #[inline]
         pub fn render(self, name: &'static str) -> impl IntoHtml {
             if self.0 {
-                Some((PreEscaped(" "), PreEscaped(name)))
+                Some((PreEscaped(' '), PreEscaped(name)))
             } else {
                 None
             }
@@ -36,7 +36,7 @@ pub mod __macro_support {
         pub fn render(self, name: &'static str) -> impl IntoHtml {
             self.0.map(|v| {
                 (
-                    PreEscaped(" "),
+                    PreEscaped(' '),
                     PreEscaped(name),
                     PreEscaped("=\""),
                     v,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,39 @@ pub use vy_macros::*;
 
 pub const DOCTYPE: PreEscaped<&'static str> = PreEscaped("<!DOCTYPE html>");
 
+#[doc(hidden)]
+pub mod __macro_support {
+    use vy_core::{escape::PreEscaped, IntoHtml};
+
+    pub struct OptionalAttr<T>(pub T);
+
+    impl OptionalAttr<bool> {
+        #[inline]
+        pub fn render(self, name: &'static str) -> impl IntoHtml {
+            if self.0 {
+                Some((PreEscaped(" "), PreEscaped(name)))
+            } else {
+                None
+            }
+        }
+    }
+
+    impl<T: IntoHtml> OptionalAttr<Option<T>> {
+        #[inline]
+        pub fn render(self, name: &'static str) -> impl IntoHtml {
+            self.0.map(|v| {
+                (
+                    PreEscaped(" "),
+                    PreEscaped(name),
+                    PreEscaped("=\""),
+                    v,
+                    PreEscaped('"'),
+                )
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Without this change only literal boolean attr, e.g. `button!(disabled? = true)` compiles, while `disabled? = my_condition` doesn't